### PR TITLE
Move loadTranslationsFrom() call to boot method

### DIFF
--- a/src/Stevebauman/Inventory/InventoryServiceProvider.php
+++ b/src/Stevebauman/Inventory/InventoryServiceProvider.php
@@ -24,8 +24,7 @@ class InventoryServiceProvider extends ServiceProvider {
 
 		} else {
 
-			$this->loadTranslationsFrom(__DIR__.'/../../lang', 'inventory');
-
+			
 			$this->publishes([
 				__DIR__ . '/../../config/config.php' => config_path('inventory.php'),
 			], 'config');
@@ -55,6 +54,18 @@ class InventoryServiceProvider extends ServiceProvider {
 		));
 
 		include __DIR__ .'/../../helpers.php';
+	}
+	
+	/**
+	 * Boot the service provider.
+	 *
+	 * @return void
+	 */
+	public function boot()
+	{
+		if(!method_exists($this, 'package')) {
+			$this->loadTranslationsFrom(__DIR__ . '/../../lang', 'inventory');
+		}
 	}
 
 	/**


### PR DESCRIPTION
Translations need to be loaded in the boot method as the translator class does not exist during registration and an exception is thrown.